### PR TITLE
fix beBuff2int. Add test for utils

### DIFF
--- a/src/utils_native.js
+++ b/src/utils_native.js
@@ -36,16 +36,20 @@ module.exports.unstringifyBigInts = function unstringifyBigInts(o) {
 module.exports.beBuff2int = function beBuff2int(buff) {
     let res = 0n;
     let i = buff.length;
+    let offset = 0;
     while (i>0) {
         if (i >= 4) {
             i -= 4;
-            res += BigInt(buff.readUInt32BE(i)) << BigInt( i*8);
+            res += BigInt(buff.readUInt32BE(i)) << BigInt(offset*8);
+            offset += 4;
         } else if (i >= 2) {
             i -= 2;
-            res += BigInt(buff.readUInt16BE(i)) << BigInt( i*8);
+            res += BigInt(buff.readUInt16BE(i)) << BigInt(offset*8);
+            offset += 2;
         } else {
             i -= 1;
-            res += BigInt(buff.readUInt8(i)) << BigInt( i*8);
+            res += BigInt(buff.readUInt8(i)) << BigInt(offset*8);
+            offset += 1;
         }
     }
     return res;

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,0 +1,57 @@
+const assert = require("assert");
+
+const ScalarN = require("../src/scalar_native.js");
+const ScalarB = require("../src/scalar_bigint.js");
+
+const utilsN = require("../src/utils_native.js");
+const utilsB = require("../src/utils_bigint.js");
+
+describe("Utils native", () => {
+    const num = ScalarN.e(21888242871839275222246405745257275088614511777268538073601725287587578984328);
+
+    it("Should convert integer to buffer little-endian", () => {
+        const buff = utilsN.leInt2Buff(num, 32);
+        const numFromBuff = utilsN.leBuff2int(buff);
+      
+        assert(ScalarN.eq(num, numFromBuff), true);
+    });
+
+    it("Should convert integer to buffer big-endian", () => {
+        const buff = utilsN.beInt2Buff(num, 32);
+        const numFromBuff = utilsN.beBuff2int(buff);
+    
+        assert(ScalarN.eq(num, numFromBuff), true);
+    });
+
+    it("Should stringify bigInt", () => {
+        const str = utilsN.stringifyBigInts(num);
+        const numFromStr = utilsN.unstringifyBigInts(str);
+    
+        assert(ScalarN.eq(num, numFromStr), true);
+    });
+});
+
+describe("Utils bigInt", () => {
+    const num = ScalarB.e(21888242871839275222246405745257275088614511777268538073601725287587578984328);
+
+    it("Should convert integer to buffer little-endian", () => {
+        const buff = utilsB.leInt2Buff(num, 32);
+        const numFromBuff = utilsB.leBuff2int(buff);
+      
+        assert(ScalarB.eq(num, numFromBuff), true);
+    });
+
+    it("Should convert integer to buffer big-endian", () => {
+        const buff = utilsB.beInt2Buff(num, 32);
+        const numFromBuff = utilsB.beBuff2int(buff);
+    
+        assert(ScalarB.eq(num, numFromBuff), true);
+    });
+
+    it("Should stringify bigInt", () => {
+        const str = utilsB.stringifyBigInts(num);
+        const numFromStr = utilsB.unstringifyBigInts(str);
+    
+        assert(ScalarB.eq(num, numFromStr), true);
+    });
+});


### PR DESCRIPTION
- Fix function `beBuff2int` in `utils_native.js`

- Add test for utils, both `native` and `big-integer`