### PR TITLE
allow Js Number conversion to MAX_SAFE_INTEGER

### DIFF
--- a/src/scalar_bigint.js
+++ b/src/scalar_bigint.js
@@ -79,7 +79,7 @@ module.exports.bits = function naf(n) {
 };
 
 module.exports.toNumber = function(s) {
-    assert(s.lt(bigInt("100000000", 16)));
+    assert(s.lt(bigInt("9007199254740992", 10)));
     return s.toJSNumber();
 };
 

--- a/src/scalar_native.js
+++ b/src/scalar_native.js
@@ -86,7 +86,7 @@ module.exports.bits = function naf(n) {
 };
 
 module.exports.toNumber = function(s) {
-    assert(s<0x100000000n);
+    assert(s<BigInt(Number.MAX_SAFE_INTEGER + 1));
     return Number(s);
 };
 

--- a/test/scalar.js
+++ b/test/scalar.js
@@ -27,4 +27,24 @@ describe("Basic scalar convertions", () => {
         assert(ScalarB.eq(ScalarB.e(0x12, 10), 18));
         assert(ScalarB.eq(ScalarB.e(0x12n, 10), 18));
     });
+    it("Should convert to js Number Native", () => {
+        const maxJsNum = Number.MAX_SAFE_INTEGER;
+        const maxToScalar = ScalarN.e(maxJsNum);
+
+        const backToNum = ScalarN.toNumber(maxToScalar);
+        assert(backToNum, maxJsNum);
+
+        const overMaxJsNum = ScalarN.add(maxToScalar, 1);
+        assert.throws(() => ScalarN.toNumber(overMaxJsNum));
+    });
+    it("Should convert to js Number BigInt", () => {
+        const maxJsNum = Number.MAX_SAFE_INTEGER;
+        const maxToScalar = ScalarB.e(maxJsNum);
+
+        const backToNum = ScalarB.toNumber(maxToScalar);
+        assert(backToNum, maxJsNum);
+
+        const overMaxJsNum = ScalarB.add(maxToScalar, 1);
+        assert.throws(() => ScalarB.toNumber(overMaxJsNum));
+    });
 });


### PR DESCRIPTION
- Allow function `Scalar.toNumber()` to return a  javascript native number up to its maximum value 2⁵³ - 1
- add test to verify `Scalar.toNumber()` conversion