### PR TITLE
small fix dataView buffer

### DIFF
--- a/src/utils_native.js
+++ b/src/utils_native.js
@@ -89,7 +89,7 @@ export function beInt2Buff(n, len) {
 export function leBuff2int(buff) {
     let res = 0n;
     let i = 0;
-    const buffV = new DataView(buff.buffer);
+    const buffV = new DataView(buff.buffer, buff.byteOffset);
     while (i<buff.length) {
         if (i + 4 <= buff.length) {
             res += BigInt(buffV.getUint32(i, true)) << BigInt( i*8);

--- a/test/utils.js
+++ b/test/utils.js
@@ -12,10 +12,18 @@ describe("Utils native", () => {
     it("Should convert integer to buffer little-endian", () => {
         const buff = utilsN.leInt2Buff(num, 32);
         const numFromBuff = utilsN.leBuff2int(buff);
-
+        
         assert(ScalarN.eq(num, numFromBuff), true);
     });
 
+    it("Should convert integer to buffer little-endian 2", () => {
+        const buff1 = Buffer.from("Rollup_DB_EthAddr"); 
+        const buff2= Buffer.from("Rollup_DB_ChainID");
+        const numFromBuff = utilsN.leBuff2int(buff1);
+        const numFromBuff2 = utilsN.leBuff2int(buff2);
+
+        assert.equal(ScalarN.eq(numFromBuff, numFromBuff2), false)
+    });
     it("Should convert integer to buffer big-endian", () => {
         const buff = utilsN.beInt2Buff(num, 32);
         const numFromBuff = utilsN.beBuff2int(buff);


### PR DESCRIPTION
This PR is just to point the error, but is not a fix, it should change all the `DataView` calls

As it says here https://nodejs.org/api/buffer.html#buffer_buf_byteoffset, "When setting byteOffset in Buffer.from(ArrayBuffer, byteOffset, length), or sometimes when allocating a Buffer smaller than Buffer.poolSize, the buffer does not start from a zero offset on the underlying ArrayBuffer." 
That's why when: `new DataView(buff.buffer);` it is necessary to input the offset aswell -->  `const buffV = new DataView(buff.buffer, buff.byteOffset);`
