### PR TITLE
fix: use relative path for threadman_thread import

### DIFF
--- a/src/threadman.browser.js
+++ b/src/threadman.browser.js
@@ -22,7 +22,7 @@
 const MEM_SIZE = 25;  // Memory size in 64K Pakes (1600Kb)
 
 
-import thread from "ffjavascript/src/threadman_thread";
+import thread from "./threadman_thread.js";
 import os from "os";
 
 class Deferred {


### PR DESCRIPTION
## What I did

I converted the import of `threadman_thread` to a relative import. If you don't use a relative import, node and rollup don't know how to find the module file because it isn't included in the "exports" inside package.json.