### PR TITLE
fix: Convert global & window references to globalThis

### DIFF
--- a/build/main.cjs
+++ b/build/main.cjs
@@ -1594,13 +1594,11 @@ class ChaCha {
     }
 }
 
-/* global window */
-
 function getRandomBytes(n) {
     let array = new Uint8Array(n);
-    if (typeof window !== "undefined") { // Browser
-        if (typeof window.crypto !== "undefined") { // Supported
-            window.crypto.getRandomValues(array);
+    if (process.browser) { // Browser
+        if (typeof globalThis.crypto !== "undefined") { // Supported
+            globalThis.crypto.getRandomValues(array);
         } else { // fallback
             for (let i=0; i<n; i++) {
                 array[i] = (Math.random()*4294967296)>>>0;
@@ -4860,7 +4858,7 @@ function thread(self) {
     return runTask;
 }
 
-/* global window, navigator, Blob, Worker, WebAssembly */
+/* global navigator, WebAssembly */
 /*
     Copyright 2019 0KIMS association.
 
@@ -4898,7 +4896,7 @@ function sleep(ms) {
 
 function base64ToArrayBuffer(base64) {
     if (process.browser) {
-        var binary_string = window.atob(base64);
+        var binary_string = globalThis.atob(base64);
         var len = binary_string.length;
         var bytes = new Uint8Array(len);
         for (var i = 0; i < len; i++) {
@@ -4912,7 +4910,7 @@ function base64ToArrayBuffer(base64) {
 
 function stringToBase64(str) {
     if (process.browser) {
-        return window.btoa(str);
+        return globalThis.btoa(str);
     } else {
         return Buffer.from(str).toString("base64");
     }
@@ -6329,11 +6327,11 @@ async function buildEngine(params) {
     return curve;
 }
 
-global.curve_bn128 = null;
+globalThis.curve_bn128 = null;
 
 async function buildBn128(singleThread) {
 
-    if ((!singleThread)&&(global.curve_bn128)) return global.curve_bn128;
+    if ((!singleThread)&&(globalThis.curve_bn128)) return globalThis.curve_bn128;
     const params = {
         name: "bn128",
         wasm: wasmcurves__default['default'].bn128_wasm,
@@ -6348,23 +6346,23 @@ async function buildBn128(singleThread) {
     const curve = await buildEngine(params);
     curve.terminate = async function() {
         if (!params.singleThread) {
-            global.curve_bn128 = null;
+            globalThis.curve_bn128 = null;
             await this.tm.terminate();
         }
     };
 
     if (!singleThread) {
-        global.curve_bn128 = curve;
+        globalThis.curve_bn128 = curve;
     }
 
     return curve;
 }
 
-global.curve_bls12381 = null;
+globalThis.curve_bls12381 = null;
 
 async function buildBls12381(singleThread) {
 
-    if ((!singleThread)&&(global.curve_bls12381)) return global.curve_bls12381;
+    if ((!singleThread)&&(globalThis.curve_bls12381)) return globalThis.curve_bls12381;
     const params = {
         name: "bls12381",
         wasm: wasmcurves__default['default'].bls12381_wasm,
@@ -6380,7 +6378,7 @@ async function buildBls12381(singleThread) {
     const curve = await buildEngine(params);
     curve.terminate = async function() {
         if (!params.singleThread) {
-            global.curve_bls12381 = null;
+            globalThis.curve_bls12381 = null;
             await this.tm.terminate();
         }
     };

--- a/src/bls12381.js
+++ b/src/bls12381.js
@@ -2,11 +2,11 @@ import wasmcurves from "wasmcurves";
 import buildEngine from "./engine.js";
 import * as Scalar from "./scalar.js";
 
-global.curve_bls12381 = null;
+globalThis.curve_bls12381 = null;
 
 export default async function buildBls12381(singleThread) {
 
-    if ((!singleThread)&&(global.curve_bls12381)) return global.curve_bls12381;
+    if ((!singleThread)&&(globalThis.curve_bls12381)) return globalThis.curve_bls12381;
     const params = {
         name: "bls12381",
         wasm: wasmcurves.bls12381_wasm,
@@ -22,7 +22,7 @@ export default async function buildBls12381(singleThread) {
     const curve = await buildEngine(params);
     curve.terminate = async function() {
         if (!params.singleThread) {
-            global.curve_bls12381 = null;
+            globalThis.curve_bls12381 = null;
             await this.tm.terminate();
         }
     };

--- a/src/bn128.js
+++ b/src/bn128.js
@@ -2,11 +2,11 @@ import wasmcurves from "wasmcurves";
 import buildEngine from "./engine.js";
 import * as Scalar from "./scalar.js";
 
-global.curve_bn128 = null;
+globalThis.curve_bn128 = null;
 
 export default async function buildBn128(singleThread) {
 
-    if ((!singleThread)&&(global.curve_bn128)) return global.curve_bn128;
+    if ((!singleThread)&&(globalThis.curve_bn128)) return globalThis.curve_bn128;
     const params = {
         name: "bn128",
         wasm: wasmcurves.bn128_wasm,
@@ -21,13 +21,13 @@ export default async function buildBn128(singleThread) {
     const curve = await buildEngine(params);
     curve.terminate = async function() {
         if (!params.singleThread) {
-            global.curve_bn128 = null;
+            globalThis.curve_bn128 = null;
             await this.tm.terminate();
         }
     };
 
     if (!singleThread) {
-        global.curve_bn128 = curve;
+        globalThis.curve_bn128 = curve;
     }
 
     return curve;

--- a/src/random.js
+++ b/src/random.js
@@ -1,12 +1,11 @@
-/* global window */
 import ChaCha from "./chacha.js";
 import crypto from "crypto";
 
 export function getRandomBytes(n) {
     let array = new Uint8Array(n);
-    if (typeof window !== "undefined") { // Browser
-        if (typeof window.crypto !== "undefined") { // Supported
-            window.crypto.getRandomValues(array);
+    if (process.browser) { // Browser
+        if (typeof globalThis.crypto !== "undefined") { // Supported
+            globalThis.crypto.getRandomValues(array);
         } else { // fallback
             for (let i=0; i<n; i++) {
                 array[i] = (Math.random()*4294967296)>>>0;

--- a/src/threadman.js
+++ b/src/threadman.js
@@ -1,4 +1,4 @@
-/* global window, navigator, Blob, Worker, WebAssembly */
+/* global navigator, WebAssembly */
 /*
     Copyright 2019 0KIMS association.
 
@@ -41,7 +41,7 @@ function sleep(ms) {
 
 function base64ToArrayBuffer(base64) {
     if (process.browser) {
-        var binary_string = window.atob(base64);
+        var binary_string = globalThis.atob(base64);
         var len = binary_string.length;
         var bytes = new Uint8Array(len);
         for (var i = 0; i < len; i++) {
@@ -55,7 +55,7 @@ function base64ToArrayBuffer(base64) {
 
 function stringToBase64(str) {
     if (process.browser) {
-        return window.btoa(str);
+        return globalThis.btoa(str);
     } else {
         return Buffer.from(str).toString("base64");
     }


### PR DESCRIPTION
This converts references to `global` and `window` with `globalThis`. According to [the MDN article](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/globalThis#description):
> The `globalThis` property provides a standard way of accessing the global `this` value (and hence the global object itself) across environments. Unlike similar properties such as `window` and `self`, it's guaranteed to work in window and non-window contexts. In this way, you can access the global object in a consistent manner without having to know which environment the code is being run in.

The biggest benefit to this will be that SnarkJS itself will be able to be run in a WebWorker! Additionally, we should be able to remove the `global` shim that is applied by the SnarkJS iife build script.

The [Compatibility chart](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/globalThis#browser_compatibility) seems to indicate that this has good coverage, and was even added in Node.js v12 (which I believe is oldest version of node that SnarkJS supports).

I also updated some browser detection to use `process.browser` because the SnarkJS build tool injects that value in browser builds.