### PR TITLE
fix: Leverage new web-worker dep to close workers cross-platform

### DIFF
--- a/build/main.cjs
+++ b/build/main.cjs
@@ -4756,7 +4756,7 @@ function thread(self) {
                     self.postMessage(data.result);
                 });
             } else if (data[0].cmd == "TERMINATE") {
-                process.exit();
+                self.close();
             } else {
                 const res = runTask(data);
                 self.postMessage(res);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1608,9 +1608,9 @@
       }
     },
     "node_modules/web-worker": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/web-worker/-/web-worker-1.0.0.tgz",
-      "integrity": "sha512-BzuMqeKVkKKwHV6tJuwePFcxYMxvC97D448mXTgh/CxXAB4sRtoV26gRPN+JDxsXRR7QZyioMV9O6NzQaASf7Q=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/web-worker/-/web-worker-1.2.0.tgz",
+      "integrity": "sha512-PgF341avzqyx60neE9DD+XS26MMNMoUQRz9NOZwW32nPQrF6p77f1htcnjBSEV8BGMKZ16choqUG4hyI0Hx7mA=="
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "big-integer": "^1.6.48",
     "wasmcurves": "0.0.14",
-    "web-worker": "^1.0.0"
+    "web-worker": "^1.2.0"
   },
   "devDependencies": {
     "blake2b": "^2.1.3",

--- a/src/threadman_thread.js
+++ b/src/threadman_thread.js
@@ -19,7 +19,7 @@ export default function thread(self) {
                     self.postMessage(data.result);
                 });
             } else if (data[0].cmd == "TERMINATE") {
-                process.exit();
+                self.close();
             } else {
                 const res = runTask(data);
                 self.postMessage(res);


### PR DESCRIPTION
I was digging into the usage of `process.exit()` to close the worker and found that it only works inside nodejs. However, the WebWorker spec provides requires a `self.close()` in a Worker's global scope (docs at https://developer.mozilla.org/en-US/docs/Web/API/DedicatedWorkerGlobalScope/close)

So I upstreamed a fix to the web-worker dependency at https://github.com/developit/web-worker/pull/21 and now we can use a cross-platform `self.close()` to terminate the workers!