### PR TITLE
fix: Assign bls12381 to global when not single thread

### DIFF
--- a/build/main.cjs
+++ b/build/main.cjs
@@ -6383,6 +6383,10 @@ async function buildBls12381(singleThread) {
         }
     };
 
+    if (!singleThread) {
+        globalThis.curve_bls12381 = curve;
+    }
+
     return curve;
 }
 
@@ -6397,7 +6401,7 @@ async function getCurveFromR(r, singleThread) {
     if (eq$2(r, bn128r)) {
         curve = await buildBn128(singleThread);
     } else if (eq$2(r, bls12381r)) {
-        curve = await buildBn128(singleThread);
+        curve = await buildBls12381(singleThread);
     } else {
         throw new Error(`Curve not supported: ${toString(r)}`);
     }
@@ -6409,7 +6413,7 @@ async function getCurveFromQ(q, singleThread) {
     if (eq$2(q, bn128q)) {
         curve = await buildBn128(singleThread);
     } else if (eq$2(q, bls12381q)) {
-        curve = await buildBn128(singleThread);
+        curve = await buildBls12381(singleThread);
     } else {
         throw new Error(`Curve not supported: ${toString(q)}`);
     }
@@ -6422,7 +6426,7 @@ async function getCurveFromName(name, singleThread) {
     if (["BN128", "BN254", "ALTBN128"].indexOf(normName) >= 0) {
         curve = await buildBn128(singleThread);
     } else if (["BLS12381"].indexOf(normName) >= 0) {
-        curve = await buildBn128(singleThread);
+        curve = await buildBls12381(singleThread);
     } else {
         throw new Error(`Curve not supported: ${name}`);
     }

--- a/src/bls12381.js
+++ b/src/bls12381.js
@@ -27,6 +27,10 @@ export default async function buildBls12381(singleThread) {
         }
     };
 
+    if (!singleThread) {
+        globalThis.curve_bls12381 = curve;
+    }
+
     return curve;
 }
 


### PR DESCRIPTION
Closes #9 (actually closed in #22 but this regens the main.cjs file)
Closes #10

I noticed that #22 fixed half of the issues pointed out in #10 but not the global curve and we changed the convention to use `globalThis`