### PR TITLE
Fix number of threads calculation in Safari.

### DIFF
--- a/src/threadman.js
+++ b/src/threadman.js
@@ -116,6 +116,11 @@ export default async function buildThreadManager(wasm, singleThread) {
         } else {
             concurrency = os.cpus().length;
         }
+
+        if(concurrency == 0){
+            concurrency = 2;
+        }
+
         // Limit to 64 threads for memory reasons.
         if (concurrency>64) concurrency=64;
         tm.concurrency = concurrency;


### PR DESCRIPTION
In Safari browser navigator.hardwareConcurrency is disabled by default
https://caniuse.com/hardwareconcurrency

And it leads to the situation when the number of threads is 0, because navigator.hardwareConcurrency is empty and os.cpus() returns zero.

This is why proof is not generated.