### PR TITLE
export ThreadManager to allow auto-generation of TypeScript types

### DIFF
--- a/src/threadman.js
+++ b/src/threadman.js
@@ -166,7 +166,7 @@ export default async function buildThreadManager(wasm, singleThread) {
 
 }
 
-class ThreadManager {
+export class ThreadManager {
     constructor() {
         this.actionQueue = [];
         this.oldPFree = 0;


### PR DESCRIPTION
`threadman.js` exports the `buildThreadManager()` function which returns an instance of the `ThreadManager` class.

However the `ThreadManager` class itself is not exported.  This can be problematic; for instance, when auto-generating TypeScript declaration files from the source via `tsc`, it results in the following error:

    src/engine.js:1:1 - error TS9006: Declaration emit for this file requires using private name 'ThreadManager' from module '"src/threadman"'. An explicit type annotation may unblock declaration emit.

    1 import WasmField1 from "./wasm_field1.js";
      ~~~~~~

This is simply solved by exporting `ThreadManager`.