### PR TITLE
Fix wasm code passed to threadman (no longer string)

### DIFF
--- a/src/bls12381.js
+++ b/src/bls12381.js
@@ -1,7 +1,7 @@
-import {buildBls12381 as buildBls12381wasm} from "wasmcurves";
-import wasmcurves from "wasmcurves";
+import { buildBls12381 as buildBls12381wasm } from "wasmcurves";
 import buildEngine from "./engine.js";
 import * as Scalar from "./scalar.js";
+import { ModuleBuilder } from "wasmbuilder";
 
 globalThis.curve_bls12381 = null;
 
@@ -13,9 +13,9 @@ export default async function buildBls12381(singleThread, plugins) {
 
     if (plugins) plugins(moduleBuilder);
 
-    const bls12381wasm  = {};
+    const bls12381wasm = {};
 
-    bls12381wasm.code= moduleBuilder.build();
+    bls12381wasm.code = moduleBuilder.build();
     bls12381wasm.pq = moduleBuilder.modules.f1m.pq;
     bls12381wasm.pr = moduleBuilder.modules.frm.pq;
     bls12381wasm.pG1gen = moduleBuilder.modules.bls12381.pG1gen;
@@ -33,7 +33,7 @@ export default async function buildBls12381(singleThread, plugins) {
     bls12381wasm.r = moduleBuilder.modules.bn128.r;
 
 
-    if ((!singleThread)&&(globalThis.curve_bls12381)) return globalThis.curve_bls12381;
+    if ((!singleThread) && (globalThis.curve_bls12381)) return globalThis.curve_bls12381;
     const params = {
         name: "bls12381",
         wasm: bls12381wasm,
@@ -47,7 +47,7 @@ export default async function buildBls12381(singleThread, plugins) {
     };
 
     const curve = await buildEngine(params);
-    curve.terminate = async function() {
+    curve.terminate = async function () {
         if (!params.singleThread) {
             globalThis.curve_bls12381 = null;
             await this.tm.terminate();

--- a/src/bn128.js
+++ b/src/bn128.js
@@ -1,9 +1,7 @@
-import wasmcurves from "wasmcurves";
-const buildBn128wasm = wasmcurves.buildBn128;
+import { buildBn128 as buildBn128wasm } from "wasmcurves";
 import buildEngine from "./engine.js";
 import * as Scalar from "./scalar.js";
-import wasmbuilder from "wasmbuilder";
-const ModuleBuilder = wasmbuilder.ModuleBuilder;
+import { ModuleBuilder } from "wasmbuilder";
 
 globalThis.curve_bn128 = null;
 
@@ -15,9 +13,9 @@ export default async function buildBn128(singleThread, plugins) {
 
     if (plugins) plugins(moduleBuilder);
 
-    const bn128wasm  = {};
+    const bn128wasm = {};
 
-    bn128wasm.code= moduleBuilder.build();
+    bn128wasm.code = moduleBuilder.build();
     bn128wasm.pq = moduleBuilder.modules.f1m.pq;
     bn128wasm.pr = moduleBuilder.modules.frm.pq;
     bn128wasm.pG1gen = moduleBuilder.modules.bn128.pG1gen;
@@ -34,7 +32,7 @@ export default async function buildBn128(singleThread, plugins) {
     bn128wasm.q = moduleBuilder.modules.bn128.q;
     bn128wasm.r = moduleBuilder.modules.bn128.r;
 
-    if ((!singleThread)&&(globalThis.curve_bn128)) return globalThis.curve_bn128;
+    if ((!singleThread) && (globalThis.curve_bn128)) return globalThis.curve_bn128;
     const params = {
         name: "bn128",
         wasm: bn128wasm,
@@ -47,7 +45,7 @@ export default async function buildBn128(singleThread, plugins) {
     };
 
     const curve = await buildEngine(params);
-    curve.terminate = async function() {
+    curve.terminate = async function () {
         if (!params.singleThread) {
             globalThis.curve_bn128 = null;
             await this.tm.terminate();


### PR DESCRIPTION
This fixes a bug introduced by the ModuleBuilder pattern. Since ModuleBuilder is providing the wasm code directly (instead of a base64-encoded string), it no longer needs to be converted, which was crashing.