### PR TITLE
[fix] Rename eval to make it SES compatible

### DIFF
--- a/build/main.cjs
+++ b/build/main.cjs
@@ -822,7 +822,7 @@ class PolField {
         return v;
     }
 
-    eval(p,x) {
+    eval1(p,x) {
         const F = this.F;
         if (p.length == 0) return F.zero;
         const m = this._next2Power(p.length);
@@ -853,7 +853,7 @@ class PolField {
             let mpol = this.ruffini(roots, points[i][0]);
             const factor =
                 this.F.mul(
-                    this.F.inv(this.eval(mpol, points[i][0])),
+                    this.F.inv(this.eval1(mpol, points[i][0])),
                     points[i][1]);
             mpol = this.mulScalar(mpol, factor);
             sum = this.add(sum, mpol);

--- a/build/main.cjs
+++ b/build/main.cjs
@@ -822,7 +822,7 @@ class PolField {
         return v;
     }
 
-    eval1(p,x) {
+    evaluate(p,x) {
         const F = this.F;
         if (p.length == 0) return F.zero;
         const m = this._next2Power(p.length);
@@ -853,7 +853,7 @@ class PolField {
             let mpol = this.ruffini(roots, points[i][0]);
             const factor =
                 this.F.mul(
-                    this.F.inv(this.eval1(mpol, points[i][0])),
+                    this.F.inv(this.evaluate(mpol, points[i][0])),
                     points[i][1]);
             mpol = this.mulScalar(mpol, factor);
             sum = this.add(sum, mpol);

--- a/src/polfield.js
+++ b/src/polfield.js
@@ -192,7 +192,7 @@ export default class PolField {
         return v;
     }
 
-    eval(p,x) {
+    eval1(p,x) {
         const F = this.F;
         if (p.length == 0) return F.zero;
         const m = this._next2Power(p.length);
@@ -223,7 +223,7 @@ export default class PolField {
             let mpol = this.ruffini(roots, points[i][0]);
             const factor =
                 this.F.mul(
-                    this.F.inv(this.eval(mpol, points[i][0])),
+                    this.F.inv(this.eval1(mpol, points[i][0])),
                     points[i][1]);
             mpol = this.mulScalar(mpol, factor);
             sum = this.add(sum, mpol);

--- a/src/polfield.js
+++ b/src/polfield.js
@@ -192,7 +192,7 @@ export default class PolField {
         return v;
     }
 
-    eval1(p,x) {
+    evaluate(p,x) {
         const F = this.F;
         if (p.length == 0) return F.zero;
         const m = this._next2Power(p.length);
@@ -223,7 +223,7 @@ export default class PolField {
             let mpol = this.ruffini(roots, points[i][0]);
             const factor =
                 this.F.mul(
-                    this.F.inv(this.eval1(mpol, points[i][0])),
+                    this.F.inv(this.evaluate(mpol, points[i][0])),
                     points[i][1]);
             mpol = this.mulScalar(mpol, factor);
             sum = this.add(sum, mpol);

--- a/test/pols.js
+++ b/test/pols.js
@@ -128,13 +128,13 @@ describe("Polynomial field", () => {
     it("Should evaluate and zero", () => {
         const PF = new PolField(new ZqField(r));
         const p = [PF.F.neg(PF.F.e(2)), PF.F.e(1)];
-        const v = PF.eval1(p, PF.F.e(2));
+        const v = PF.evaluate(p, PF.F.e(2));
         assert(PF.F.eq(v, PF.F.e(0)));
     });
     it("Should evaluate bigger number", () => {
         const PF = new PolField(new ZqField(r));
         const p = [PF.F.e(1), PF.F.e(2), PF.F.e(3)];
-        const v = PF.eval1(p, PF.F.e(2));
+        const v = PF.evaluate(p, PF.F.e(2));
         assert(PF.F.eq(v, PF.F.e(17)));
     });
     it("Should create lagrange polynomial minmal", () => {
@@ -148,7 +148,7 @@ describe("Polynomial field", () => {
         const p=PF.lagrange(points);
 
         for (let i=0; i<points.length; i++) {
-            const v = PF.eval1(p, points[i][0]);
+            const v = PF.evaluate(p, points[i][0]);
             assert(PF.F.eq(v, points[i][1]));
         }
     });
@@ -164,7 +164,7 @@ describe("Polynomial field", () => {
         const p=PF.lagrange(points);
 
         for (let i=0; i<points.length; i++) {
-            const v = PF.eval1(p, points[i][0]);
+            const v = PF.evaluate(p, points[i][0]);
             assert(PF.F.eq(v, points[i][1]));
         }
     });
@@ -211,7 +211,7 @@ describe("Polynomial field", () => {
         const p = PF.ifft(a);
 
         for (let i=0; i<a.length; i++) {
-            const s = PF.eval1(p, PF.oneRoot(8,i));
+            const s = PF.evaluate(p, PF.oneRoot(8,i));
             assert(PF.F.eq(s, a[i]));
         }
 

--- a/test/pols.js
+++ b/test/pols.js
@@ -128,13 +128,13 @@ describe("Polynomial field", () => {
     it("Should evaluate and zero", () => {
         const PF = new PolField(new ZqField(r));
         const p = [PF.F.neg(PF.F.e(2)), PF.F.e(1)];
-        const v = PF.eval(p, PF.F.e(2));
+        const v = PF.eval1(p, PF.F.e(2));
         assert(PF.F.eq(v, PF.F.e(0)));
     });
     it("Should evaluate bigger number", () => {
         const PF = new PolField(new ZqField(r));
         const p = [PF.F.e(1), PF.F.e(2), PF.F.e(3)];
-        const v = PF.eval(p, PF.F.e(2));
+        const v = PF.eval1(p, PF.F.e(2));
         assert(PF.F.eq(v, PF.F.e(17)));
     });
     it("Should create lagrange polynomial minmal", () => {
@@ -148,7 +148,7 @@ describe("Polynomial field", () => {
         const p=PF.lagrange(points);
 
         for (let i=0; i<points.length; i++) {
-            const v = PF.eval(p, points[i][0]);
+            const v = PF.eval1(p, points[i][0]);
             assert(PF.F.eq(v, points[i][1]));
         }
     });
@@ -164,7 +164,7 @@ describe("Polynomial field", () => {
         const p=PF.lagrange(points);
 
         for (let i=0; i<points.length; i++) {
-            const v = PF.eval(p, points[i][0]);
+            const v = PF.eval1(p, points[i][0]);
             assert(PF.F.eq(v, points[i][1]));
         }
     });
@@ -211,7 +211,7 @@ describe("Polynomial field", () => {
         const p = PF.ifft(a);
 
         for (let i=0; i<a.length; i++) {
-            const s = PF.eval(p, PF.oneRoot(8,i));
+            const s = PF.eval1(p, PF.oneRoot(8,i));
             assert(PF.F.eq(s, a[i]));
         }
 


### PR DESCRIPTION
Rename eval to avoid SES treat this as the builtin eval function. 
See this: https://github.com/endojs/endo/blob/f7dcf050ef0fd839ab6500b938791740c9bc702b/packages/ses/error-codes/SES_EVAL_REJECTED.md
The error I'm getting looks like this:
```
SyntaxError [Error]: Unexpected token '('
  at Object.eval (eval at makeEvaluateFactory (/Users/veronica/.config/yarn/global/node_modules/ses/dist/ses.cjs:1413:10), <anonymous>:8:30)
```