### PR TITLE
[fix] detect browser by checking if window is not undefined instead of using process.browser

### DIFF
--- a/build/main.cjs
+++ b/build/main.cjs
@@ -1596,7 +1596,7 @@ class ChaCha {
 
 function getRandomBytes(n) {
     let array = new Uint8Array(n);
-    if (process.browser) { // Browser
+    if (typeof window !== "undefined") { // Browser
         if (typeof globalThis.crypto !== "undefined") { // Supported
             globalThis.crypto.getRandomValues(array);
         } else { // fallback
@@ -5181,7 +5181,7 @@ function sleep(ms) {
 }
 
 function stringToBase64(str) {
-    if (process.browser) {
+    if (typeof window !== "undefined") {
         return globalThis.btoa(str);
     } else {
         return Buffer.from(str).toString("base64");

--- a/src/random.js
+++ b/src/random.js
@@ -3,7 +3,7 @@ import crypto from "crypto";
 
 export function getRandomBytes(n) {
     let array = new Uint8Array(n);
-    if (process.browser) { // Browser
+    if (typeof window !== "undefined") { // Browser
         if (typeof globalThis.crypto !== "undefined") { // Supported
             globalThis.crypto.getRandomValues(array);
         } else { // fallback

--- a/src/threadman.js
+++ b/src/threadman.js
@@ -40,7 +40,7 @@ function sleep(ms) {
 }
 
 function stringToBase64(str) {
-    if (process.browser) {
+    if (typeof window !== "undefined") {
         return globalThis.btoa(str);
     } else {
         return Buffer.from(str).toString("base64");


### PR DESCRIPTION
As I explain in this [issue](https://github.com/iden3/ffjavascript/issues/55) process.browser is widely deprecated. 
I checked many websites and couldn't find one that still has this property.
Conversely, any website has to have a window object, so it's impossible to be on the browser, and the type of window would be undefined.
These small changes would make the ffjavascript library browser compatible and save a lot of time for developers trying to understand why their code runs perfectly on the server side but fails with weird errors on the browser :laughing:
