### PR TITLE
fix bug in utils.leInt2Buff #28

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -123,11 +123,11 @@ export function leInt2Buff(n, len) {
             o += 4;
             r = r >> BigInt(32);
         } else if (o + 2 <= len) {
-            buffV.setUint16(Number(o, r & BigInt(0xffff)), true);
+            buffV.setUint16(o, Number(r & BigInt(0xffff)), true);
             o += 2;
             r = r >> BigInt(16);
         } else {
-            buffV.setUint8(Number(o, r & BigInt(0xff)), true);
+            buffV.setUint8(o, Number(r & BigInt(0xff)), true);
             o += 1;
             r = r >> BigInt(8);
         }

--- a/src/utils.js
+++ b/src/utils.js
@@ -97,7 +97,7 @@ export function leBuff2int(buff) {
         if (i + 4 <= buff.length) {
             res += BigInt(buffV.getUint32(i, true)) << BigInt(i * 8);
             i += 4;
-        } else if (i + 4 <= buff.length) {
+        } else if (i + 2 <= buff.length) {
             res += BigInt(buffV.getUint16(i, true)) << BigInt(i * 8);
             i += 2;
         } else {

--- a/test/utils.js
+++ b/test/utils.js
@@ -27,4 +27,22 @@ describe("Utils native", () => {
 
         assert(ScalarN.eq(num, numFromStr), true);
     });
+
+    it("Should generate buffer little-endian without trailing non-zero element", () => {
+        for (let i = 1; i < 33; i++) {
+            var buff = utilsN.leInt2Buff(BigInt(42), i);
+            for (let t = 1; t < buff.length; t++){
+                assert(buff[t] === 0, true);
+            }
+        } 
+    });
+
+    it("Should generate buffer big-endian without trailing non-zero element", () => {
+        for (let i = 1; i < 33; i++) {
+            var buff = utilsN.beInt2Buff(BigInt(42), i);
+            for (let t = 0; t < buff.length - 1; t++){
+                assert(buff[t] === 0, true);
+            }
+        } 
+    });
 });


### PR DESCRIPTION
**What type of PR is this?**

Bug Fix

\
**What does this PR do? Why is it needed?**

issue #28 pointed out **What type of PR is this?**

Bug Fix

\
**What does this PR do? Why is it needed?**

issue #28 pointed out `leInt2Buff` return depend on len, and make an explanation on why this could be potentially harmful to user not familiar with library. This bug is fixed by rearrange the function arguments.

issue #28 showed the output from the first piece of code, the truncated results of its script is now normal without any trailing 1.
```
num:  42n
leInt2Buff len = undefined:  Uint8Array(1) [ 42 ]
leInt2Buff len = 1:  Uint8Array(1) [ 42 ]
leInt2Buff len = 2:  Uint8Array(2) [ 42, 0 ]
leInt2Buff len = 3:  Uint8Array(3) [ 42, 0, 0 ]
leInt2Buff len = 4:  Uint8Array(4) [ 42, 0, 0, 0 ]
leInt2Buff len = 5:  Uint8Array(5) [ 42, 0, 0, 0, 0 ]
leInt2Buff len = 6:  Uint8Array(6) [ 42, 0, 0, 0, 0, 0 ]
leInt2Buff len = 7:  Uint8Array(7) [
  42, 0, 0, 0,
   0, 0, 0
]
leInt2Buff len = 8:  Uint8Array(8) [
  42, 0, 0, 0,
   0, 0, 0, 0
]
```

\
**Which issues(s) does this PR fix?**

bug in utils.leInt2Buff #28

\
**Other notes for review**