### PR TITLE
Use native Worker for ES module browser build

### DIFF
--- a/build/browser.esm.js
+++ b/build/browser.esm.js
@@ -2757,10 +2757,6 @@ class EC {
 
 }
 
-function getDefaultExportFromCjs (x) {
-	return x && x.__esModule && Object.prototype.hasOwnProperty.call(x, 'default') ? x['default'] : x;
-}
-
 var utils$6 = {};
 
 /*
@@ -15646,26 +15642,6 @@ function thread(self) {
     return runTask;
 }
 
-/**
- * Copyright 2020 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-var browser = Worker;
-
-var Worker$1 = /*@__PURE__*/getDefaultExportFromCjs(browser);
-
 /*
     Copyright 2019 0KIMS association.
 
@@ -15772,7 +15748,7 @@ async function buildThreadManager(wasm, singleThread) {
 
         for (let i = 0; i<concurrency; i++) {
 
-            tm.workers[i] = new Worker$1(workerSource);
+            tm.workers[i] = new Worker(workerSource);
 
             tm.workers[i].addEventListener("message", getOnMsg(i));
 

--- a/rollup.browser.esm.config.js
+++ b/rollup.browser.esm.config.js
@@ -22,6 +22,7 @@ export default [
                 * https://github.com/iden3/snarkjs/blob/ef9042451f98f254b520b8ce9b9544a849e90a5d/config/rollup.iife.config.js
                 */
                 "process.browser": true,
+                "import Worker from \"web-worker\"": "",
                 /* 
             Because of some frontend frameworks uses monkey patching to track UI changes or other purposes (including Angular, AngularJS, Ember.js, JQuery...), it's important to make sure that the thread function is not modified by the framework and passing in the web worker as it is.
         */


### PR DESCRIPTION
This PR fixes a problem with web-worker package not working with next.js: https://github.com/0xPolygonID/js-sdk/issues/198